### PR TITLE
skip .DS_store files in content_types and entries

### DIFF
--- a/lib/import/content_types.js
+++ b/lib/import/content_types.js
@@ -21,7 +21,7 @@ var contentTypesFolderPath = path.resolve(config.data, contentTypeConfig.dirName
 //var contentTypesFolderPath = path.resolve("/home/rohit/Test-import-export/contentstack-import/_backup_381", "/content_types");
 //var extensionPath = path.resolve(config.data, "mapper/extensions", "uid-mapping.json");
 var mapperFolderPath = path.join(config.data, 'mapper', 'content_types');
-var skipFiles = ['__master.json', '__priority.json', 'schema.json'];
+var skipFiles = ['__master.json', '__priority.json', 'schema.json', '.DS_Store'];
 var fileNames = fs.readdirSync(path.join(contentTypesFolderPath));
 var field_rules_ct = [];
 

--- a/lib/import/entries.js
+++ b/lib/import/entries.js
@@ -34,7 +34,7 @@ var createdEntriesWOUidPath;
 var failedWOPath;
 
 var masterLanguage = config.master_locale;
-var skipFiles = ['__master.json', '__priority.json', 'schema.json'];
+var skipFiles = ['__master.json', '__priority.json', 'schema.json', '.DS_Store'];
 var entryBatchLimit = eConfig.batchLimit || 16;
 
 function importEntries() {


### PR DESCRIPTION
Update `skipFiles` to also ignore `.DS_Store` files that are auto-created by MacOS. This prevents import failure caused by these files.